### PR TITLE
UNI-66050 organize menu items the way shotgun would expect

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -170,9 +170,11 @@ class UnityEditorEngine(Engine):
                 continue
 
             self.logger.debug("Favorite found: ", menu_name)
+            self._menu_cmd_items[menu_name]["properties"]["type"] = "favorite"
         
         from tk_create_menus.generateMenuItems import MenuItemGenerator
-        generator = MenuItemGenerator(UnityEngine.Application.dataPath, self._menu_cmd_items, "call_menu_item_callback")
+        context_name = str(self.context).decode("utf-8")
+        generator = MenuItemGenerator(UnityEngine.Application.dataPath, self._menu_cmd_items, context_name, "call_menu_item_callback")
         generator.GenerateMenuItems()
         
         # Unity domain reload has not been fully tested. There are known 

--- a/plugins/basic/tk_create_menus/generateMenuItems.py
+++ b/plugins/basic/tk_create_menus/generateMenuItems.py
@@ -2,16 +2,25 @@
 # that then populates a Unity menu with the cmd names, and calling the functions in python.
 
 import os
+from collections import defaultdict
 
 class MenuItemGenerator(object):
-    def __init__(self, projectPath, cmdItems, callbackName):
+    def __init__(self, projectPath, cmdItems, contextName, callbackName):
         self._cSharpClass = "ShotgunMenuItems"
         self._cmdItems = cmdItems
         self._callbackName = callbackName
         self._projectPath = projectPath
+        self._contextName = contextName # name for context menu item folder
+        self._contextMenuFormat = self._contextName + "/{0}"
+        
+        # The difference in priorities will add separators between the three menu sections
+        # as a priority increase of 10 or more creates a separator.
+        # Note: default dict will use 22 as the default value if the key doesn't match any of the other keys
+        self._priorities = defaultdict(lambda:22, context_menu=0, favorite=11)
+        
         self._functionList = []
         self._functionTemplate = """
-            [MenuItem("Shotgun/{menuName}")]
+            [MenuItem("Shotgun/{menuName}", false, {priority})]
             public static void MenuItem{count}(){{
                 PythonRunner.RunString("import sgtk\\nsgtk.platform.current_engine().{callbackName}('{menuName}')");
             }}
@@ -37,15 +46,21 @@ class MenuItemGenerator(object):
             if cSharpFile:
                 cSharpFile.close()
     
-    def GenerateMenuItem(self, cmdName):
+    def GenerateMenuItem(self, cmdName, cmdType):
         count = len(self._functionList) + 1
+        
+        menuName = cmdName
+        if cmdType == "context_menu":
+            menuName = self._contextMenuFormat.format(cmdName)
+        
         self._functionList.append(
             self._functionTemplate.format(
-                count = count, menuName = cmdName, callbackName = self._callbackName
+                count = count, menuName = menuName, callbackName = self._callbackName, priority = self._priorities[cmdType]
                 )
             )
 
     def GenerateMenuItems(self):
-        for key in self._cmdItems:
-            self.GenerateMenuItem(key)
+        for (key, value) in self._cmdItems.items():
+            type = value["properties"].get("type", "default")
+            self.GenerateMenuItem(key, type)
         self.CreateCSharpFile()


### PR DESCRIPTION
- organize by context, favorites, and others with separators in between
- organize context menu items as a subfolder of the context name